### PR TITLE
Show event times in system's default timezone

### DIFF
--- a/app/src/main/java/bisq/android/util/DateUtil.kt
+++ b/app/src/main/java/bisq/android/util/DateUtil.kt
@@ -36,13 +36,12 @@ class DateUtil : JsonDeserializer<Date> {
         private const val TAG = "DateDeserializer"
         private val LOCALE = Locale.US
         private const val PATTERN = "yyyy-MM-dd HH:mm:ss"
-        private val TIMEZONE = TimeZone.getDefault()
 
         fun format(
             date: Long,
             locale: Locale = LOCALE,
             pattern: String = PATTERN,
-            timezone: TimeZone = TIMEZONE
+            timezone: TimeZone = TimeZone.getDefault()
         ): String? {
             val formatter = SimpleDateFormat(pattern, locale)
             formatter.timeZone = timezone
@@ -68,7 +67,7 @@ class DateUtil : JsonDeserializer<Date> {
     ): Date? {
         val date = element.asString
         val formatter = SimpleDateFormat(PATTERN, LOCALE)
-        formatter.timeZone = TimeZone.getTimeZone("UTC")
+        formatter.timeZone = TimeZone.getDefault()
 
         return try {
             formatter.parse(date)

--- a/app/src/main/java/bisq/android/util/DateUtil.kt
+++ b/app/src/main/java/bisq/android/util/DateUtil.kt
@@ -36,14 +36,16 @@ class DateUtil : JsonDeserializer<Date> {
         private const val TAG = "DateDeserializer"
         private val LOCALE = Locale.US
         private const val PATTERN = "yyyy-MM-dd HH:mm:ss"
+        private val TIMEZONE = TimeZone.getDefault()
 
         fun format(
             date: Long,
             locale: Locale = LOCALE,
-            pattern: String = PATTERN
+            pattern: String = PATTERN,
+            timezone: TimeZone = TIMEZONE
         ): String? {
             val formatter = SimpleDateFormat(pattern, locale)
-            formatter.timeZone = TimeZone.getDefault()
+            formatter.timeZone = timezone
             return formatter.format(date)
         }
     }
@@ -66,7 +68,7 @@ class DateUtil : JsonDeserializer<Date> {
     ): Date? {
         val date = element.asString
         val formatter = SimpleDateFormat(PATTERN, LOCALE)
-        formatter.timeZone = TimeZone.getDefault()
+        formatter.timeZone = TimeZone.getTimeZone("UTC")
 
         return try {
             formatter.parse(date)

--- a/app/src/main/java/bisq/android/util/DateUtil.kt
+++ b/app/src/main/java/bisq/android/util/DateUtil.kt
@@ -43,7 +43,7 @@ class DateUtil : JsonDeserializer<Date> {
             pattern: String = PATTERN
         ): String? {
             val formatter = SimpleDateFormat(pattern, locale)
-            formatter.timeZone = TimeZone.getTimeZone("UTC")
+            formatter.timeZone = TimeZone.getDefault()
             return formatter.format(date)
         }
     }
@@ -66,7 +66,7 @@ class DateUtil : JsonDeserializer<Date> {
     ): Date? {
         val date = element.asString
         val formatter = SimpleDateFormat(PATTERN, LOCALE)
-        formatter.timeZone = TimeZone.getTimeZone("UTC")
+        formatter.timeZone = TimeZone.getDefault()
 
         return try {
             formatter.parse(date)

--- a/app/src/test/java/bisq/android/tests/util/DateUtilTest.kt
+++ b/app/src/test/java/bisq/android/tests/util/DateUtilTest.kt
@@ -22,9 +22,12 @@ import com.google.gson.Gson
 import com.google.gson.JsonObject
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
+import org.junit.Assume.assumeFalse
+import org.junit.Assume.assumeTrue
 import org.junit.Test
 import java.util.Date
 import java.util.Locale
+import java.util.TimeZone
 
 class DateUtilTest {
 
@@ -32,17 +35,31 @@ class DateUtilTest {
 
     @Test
     fun testDefaultFormatReturnsFormattedString() {
-        assertEquals("2022-05-08 01:46:43", DateUtil.format(1651974403000L))
+        assertEquals("2022-05-08 01:46:43", DateUtil.format(1651974403000L, timezone = TimeZone.getTimeZone("UTC")))
     }
 
     @Test
     fun testFormatWithSpecifiedLocaleReturnsFormattedString() {
-        assertEquals("2022-05-08 01:46:43", DateUtil.format(1651974403000L, Locale.GERMAN))
+        assertEquals("2022-05-08 01:46:43", DateUtil.format(1651974403000L, Locale.GERMAN, timezone = TimeZone.getTimeZone("UTC")))
     }
 
     @Test
     fun testFormatWithSpecifiedPatternReturnsFormattedString() {
-        assertEquals("08/05/2022", DateUtil.format(1651974403000L, Locale.US, "dd/MM/yyyy"))
+        assertEquals("08/05/2022", DateUtil.format(1651974403000L, pattern = "dd/MM/yyyy", timezone = TimeZone.getTimeZone("UTC")))
+    }
+
+    @Test
+    fun testFormatWithSpecifiedTimezoneReturnsFormattedString() {
+        val tz = TimeZone.getTimeZone("Pacific/Galapagos") // UTC-6 always
+        assumeFalse(tz.inDaylightTime(Date()))
+        assertEquals("2022-05-07 19:46:43", DateUtil.format(1651974403000L, timezone = tz))
+    }
+
+    @Test
+    fun testFormatWithSpecifiedTimezoneDSTReturnsFormattedString() {
+        val tz = TimeZone.getTimeZone("Europe/Helsinki") // UTC+3 when DST in effect
+        assumeTrue(tz.inDaylightTime(Date()))
+        assertEquals("2022-05-08 04:46:43", DateUtil.format(1651974403000L, timezone = tz))
     }
 
     @Test

--- a/app/src/test/java/bisq/android/tests/util/DateUtilTest.kt
+++ b/app/src/test/java/bisq/android/tests/util/DateUtilTest.kt
@@ -24,6 +24,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Assume.assumeFalse
 import org.junit.Assume.assumeTrue
+import org.junit.BeforeClass
 import org.junit.Test
 import java.util.Date
 import java.util.Locale
@@ -33,19 +34,27 @@ class DateUtilTest {
 
     private val dateUtil = DateUtil()
 
+    companion object {
+        @BeforeClass
+        @JvmStatic
+        fun init() {
+            TimeZone.setDefault(TimeZone.getTimeZone("UTC"))
+        }
+    }
+
     @Test
     fun testDefaultFormatReturnsFormattedString() {
-        assertEquals("2022-05-08 01:46:43", DateUtil.format(1651974403000L, timezone = TimeZone.getTimeZone("UTC")))
+        assertEquals("2022-05-08 01:46:43", DateUtil.format(1651974403000L))
     }
 
     @Test
     fun testFormatWithSpecifiedLocaleReturnsFormattedString() {
-        assertEquals("2022-05-08 01:46:43", DateUtil.format(1651974403000L, Locale.GERMAN, timezone = TimeZone.getTimeZone("UTC")))
+        assertEquals("2022-05-08 01:46:43", DateUtil.format(1651974403000L, Locale.GERMAN))
     }
 
     @Test
     fun testFormatWithSpecifiedPatternReturnsFormattedString() {
-        assertEquals("08/05/2022", DateUtil.format(1651974403000L, pattern = "dd/MM/yyyy", timezone = TimeZone.getTimeZone("UTC")))
+        assertEquals("08/05/2022", DateUtil.format(1651974403000L, pattern = "dd/MM/yyyy"))
     }
 
     @Test


### PR DESCRIPTION
Fixes #30

Event timestamps will be displayed in the system's default timezone instead of hardcoded UTC+0