### PR TITLE
Remove unused AD_ID permission

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,9 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission
+        android:name="com.google.android.gms.permission.AD_ID"
+        tools:node="remove" />
 
     <application
         android:name=".Application"


### PR DESCRIPTION
It seems the Firebase SDK uses, and includes in its own manifest, the AD_ID permission. We don't use, nor want, advertising tracking so override this permission to remove it.